### PR TITLE
Fix naming of libintl.h on win

### DIFF
--- a/recipe/install-libintl-devel.bat
+++ b/recipe/install-libintl-devel.bat
@@ -3,7 +3,7 @@
 if not exist %LIBRARY_PREFIX%\include md %LIBRARY_PREFIX%\include
 if errorlevel 1 exit 1
 
-copy gettext-runtime\intl\libintl.h %LIBRARY_PREFIX%\include\intl.h
+copy gettext-runtime\intl\libintl.h %LIBRARY_PREFIX%\include\libintl.h
 if errorlevel 1 exit 1
 
 if not exist %LIBRARY_PREFIX%\lib md %LIBRARY_PREFIX%\lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - 0008-Avoid-close-inconsistencies.patch                           # [win]
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - libcxx
     - libstdcxx-ng
@@ -78,8 +78,10 @@ outputs:
         - if not exist %PREFIX%\Library\bin\intl-*.dll exit /b 1  # [win]
         # The unversioned variants as well as the lib on Windows should be in the main gettext package.
         - test ! -f ${PREFIX}/lib/libintl$SHLIB_EXT               # [not win]
+        - test ! -f ${PREFIX}/include/libintl.h                   # [osx]
         - if exist %PREFIX%\Library\lib\intl.dll.lib exit /b 1    # [win]
-        - if exist %PREFIX%\Library\lib\intl.lib exit /b 1    # [win]
+        - if exist %PREFIX%\Library\lib\intl.lib exit /b 1        # [win]
+        - if exist %PREFIX%\Library\include\libintl.h exit /b1    # [win]
     about:
       home: https://www.gnu.org/software/gettext/
       license: LGPL-2.1-or-later
@@ -117,8 +119,10 @@ outputs:
     test:
       commands:
         - test -f ${PREFIX}/lib/libintl${SHLIB_EXT}                   # [osx]
+        - test -f ${PREFIX}/include/libintl.h                         # [osx]
         - if not exist %PREFIX%\Library\lib\intl.dll.lib exit /b 1    # [win]
-        - if not exist %PREFIX%\Library\lib\intl.lib exit /b 1    # [win]
+        - if not exist %PREFIX%\Library\lib\intl.lib exit /b 1        # [win]
+        - if not exist %PREFIX%\Library\include\libintl.h exit /b1    # [win]
     about:
       home: https://www.gnu.org/software/gettext/
       license: LGPL-2.1-or-later


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
